### PR TITLE
Fix memory leak in From_* functions.

### DIFF
--- a/src/uxstrings1.adb
+++ b/src/uxstrings1.adb
@@ -496,9 +496,7 @@ package body UXStrings is
            Source'First + Ada.Strings.UTF_Encoding.BOM_8'Length
          else Source'First);
    begin
-      return UXS : UXString do
-         UXS.Chars := new UTF_8_Character_Array'(Source (Start .. Source'Last));
-      end return;
+      return (Ada.Finalization.Controlled with Chars => new UTF_8_Character_Array'(Source (Start .. Source'Last)), others => <>);
    end From_UTF_8;
 
    ---------------


### PR DESCRIPTION
Currently many of the From_* functions create a new UXString and then replace the Chars field without deallocating the old one. This change prevents the default Chars field from being created in the first place. I have only applied this change to uxstrings1, but the same issue exists in various places in 2 and 3.